### PR TITLE
update/accordion panels now stay open if they had previously values

### DIFF
--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -462,3 +462,11 @@ h2.address {
     grid-template-columns: auto 1fr 16px;
     align-items: center;
 }
+
+.form-check-input:checked {
+    background-color: #000 !important;
+}
+
+.accordion {
+--bs-accordion-btn-active-icon: none !important;
+}

--- a/src/main/resources/templates/common/selectCar.html
+++ b/src/main/resources/templates/common/selectCar.html
@@ -48,7 +48,7 @@
                                 Price per day
                             </button>
                         </h2>
-                        <div id="priceAcc" class="collapse"
+                        <div id="priceAcc" th:class="${carFilterForm.priceMin != null || carFilterForm.priceMax != null} ? 'collapse show' : 'collapse'"
                              aria-labelledby="price-heading">
                             <div class="accordion-body">
                                 <div class="form-group">
@@ -69,7 +69,7 @@
                                 Brand
                             </button>
                         </h2>
-                        <div id="brandAcc" class="collapse"
+                        <div id="brandAcc" th:class="${#lists.isEmpty(carFilterForm.brands)} ? 'collapse' : 'collapse show'"
                              aria-labelledby="brand-heading">
                             <div class="accordion-body">
                                 <div class="form-check" th:each="brand : ${brands}">
@@ -88,7 +88,7 @@
                                 Car type
                             </button>
                         </h2>
-                        <div id="typeAcc" class="accordion-collapse collapse"
+                        <div id="typeAcc" th:class="${#lists.isEmpty(carFilterForm.types)} ? 'accordion-collapse collapse' : 'accordion-collapse collapse show'"
                              aria-labelledby="type-heading">
                             <div class="accordion-body">
                                 <div class="form-check" th:each="type : ${types}">
@@ -107,7 +107,7 @@
                                 Seats
                             </button>
                         </h2>
-                        <div id="seatsAcc" class="accordion-collapse collapse"
+                        <div id="seatsAcc" th:class="${#lists.isEmpty(carFilterForm.seats)} ? 'accordion-collapse collapse' : 'accordion-collapse collapse show'"
                              aria-labelledby="seats-heading">
                             <div class="accordion-body">
                                 <div class="form-check" th:each="seat : ${seats}">

--- a/src/main/resources/templates/management/substituteCar.html
+++ b/src/main/resources/templates/management/substituteCar.html
@@ -59,7 +59,7 @@
                                 Price per day
                             </button>
                         </h2>
-                        <div id="priceAcc" class="collapse"
+                        <div id="priceAcc" th:class="${carFilterForm.priceMin != null || carFilterForm.priceMax != null} ? 'collapse show' : 'collapse'"
                              aria-labelledby="price-heading">
                             <div class="accordion-body">
                                 <div class="form-group">
@@ -80,7 +80,7 @@
                                 Brand
                             </button>
                         </h2>
-                        <div id="brandAcc" class="collapse"
+                        <div id="brandAcc" th:class="${#lists.isEmpty(carFilterForm.brands)} ? 'collapse' : 'collapse show'"
                              aria-labelledby="brand-heading">
                             <div class="accordion-body">
                                 <div class="form-check" th:each="brand : ${brands}">
@@ -99,7 +99,7 @@
                                 Car type
                             </button>
                         </h2>
-                        <div id="typeAcc" class="accordion-collapse collapse"
+                        <div id="typeAcc" th:class="${#lists.isEmpty(carFilterForm.types)} ? 'accordion-collapse collapse' : 'accordion-collapse collapse show'"
                              aria-labelledby="type-heading">
                             <div class="accordion-body">
                                 <div class="form-check" th:each="type : ${types}">
@@ -118,7 +118,7 @@
                                 Seats
                             </button>
                         </h2>
-                        <div id="seatsAcc" class="accordion-collapse collapse"
+                        <div id="seatsAcc" th:class="${#lists.isEmpty(carFilterForm.seats)} ? 'accordion-collapse collapse' : 'accordion-collapse collapse show'"
                              aria-labelledby="seats-heading">
                             <div class="accordion-body">
                                 <div class="form-check" th:each="seat : ${seats}">


### PR DESCRIPTION
update/accordion panels '^' jpg element is now overwritten to none 
update/active checkboxes now have overwritten bg to black