### PR TITLE
fix/incorrect double display in mg-depo and archive

### DIFF
--- a/src/main/java/com/sda/carrental/clr/PredefiniedData.java
+++ b/src/main/java/com/sda/carrental/clr/PredefiniedData.java
@@ -254,7 +254,7 @@ public class PredefiniedData implements CommandLineRunner {
         PaymentDetails pd9 = new PaymentDetails(800D, 0D, 1500D, 0D, 1500D, reservationRepository.findById(9L).get());
         PaymentDetails pd10 = new PaymentDetails(800D, 0D, 1500D, 0D, 1500D, reservationRepository.findById(10L).get());
 
-        pd1.setSecured(600D);
+        pd1.setSecured(720D);
         pd2.setSecured(700D);
         pd3.setSecured(920D);
         pd4.setSecured(900D);

--- a/src/main/java/com/sda/carrental/global/Utility.java
+++ b/src/main/java/com/sda/carrental/global/Utility.java
@@ -5,10 +5,6 @@ import org.springframework.ui.ModelMap;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.text.ParseException;
-import java.util.Locale;
 import java.util.Random;
 
 @Component
@@ -24,18 +20,6 @@ public class Utility {
         return sb.toString();
     }
 
-    public double valueToDouble(String value) {
-        DecimalFormat format = (DecimalFormat) DecimalFormat.getInstance(Locale.GERMANY);
-        DecimalFormatSymbols symbols = format.getDecimalFormatSymbols();
-        format.setDecimalFormatSymbols(symbols);
-
-        try {
-            return format.parse(value).doubleValue();
-        } catch (ParseException ignored) {
-            return 0.0;
-        }
-    }
-
     public void retrieveSessionMessage(ModelMap map, HttpServletRequest req) {
         HttpSession session = req.getSession();
         String message = (String) session.getAttribute("message");
@@ -43,5 +27,9 @@ public class Utility {
             session.removeAttribute("message");
             map.addAttribute("message", message);
         }
+    }
+
+    public Double roundCurrency(Double value) {
+        return (Math.round(value * 100.0D) / 100.0D);
     }
 }

--- a/src/main/java/com/sda/carrental/model/property/PaymentDetails.java
+++ b/src/main/java/com/sda/carrental/model/property/PaymentDetails.java
@@ -11,10 +11,10 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor
 public class PaymentDetails {
-    public PaymentDetails(Double carFee, Double divergenceFee, Double initialDeposit, Double payment, Double deposit, Reservation reservation) {
+    public PaymentDetails(Double carFee, Double divergenceFee, Double requiredDeposit, Double payment, Double deposit, Reservation reservation) {
         this.initialCarFee = carFee;
         this.initialDivergenceFee = divergenceFee;
-        this.initialDeposit = initialDeposit;
+        this.initialDeposit = requiredDeposit;
         this.payment = payment;
         this.deposit = deposit;
         this.secured = 0.0;

--- a/src/main/java/com/sda/carrental/service/CarBaseService.java
+++ b/src/main/java/com/sda/carrental/service/CarBaseService.java
@@ -178,8 +178,8 @@ public class CarBaseService {
     @Transactional
     public HttpStatus handleCarBasePricesUpdate(CarBase cb, UpdateCarBasePricesForm form) {
         try {
-            cb.setPriceDay(form.getPrice());
-            cb.setDepositValue(form.getDeposit());
+            cb.setPriceDay(Double.parseDouble(form.getPrice()));
+            cb.setDepositValue(Double.parseDouble(form.getDeposit()));
             repository.save(cb);
             return HttpStatus.ACCEPTED;
         } catch (RuntimeException err) {

--- a/src/main/java/com/sda/carrental/service/PaymentDetailsService.java
+++ b/src/main/java/com/sda/carrental/service/PaymentDetailsService.java
@@ -3,6 +3,7 @@ package com.sda.carrental.service;
 import com.sda.carrental.exceptions.IllegalActionException;
 import com.sda.carrental.exceptions.ResourceNotFoundException;
 import com.sda.carrental.global.ConstantValues;
+import com.sda.carrental.global.Utility;
 import com.sda.carrental.model.operational.Reservation;
 import com.sda.carrental.model.property.PaymentDetails;
 import com.sda.carrental.repository.PaymentDetailsRepository;
@@ -22,18 +23,22 @@ import java.util.Optional;
 public class PaymentDetailsService {
     private final PaymentDetailsRepository repository;
     private final ConstantValues cv;
+    private final Utility u;
 
     @Transactional
     public void createReservationPayment(Reservation reservation) {
         long days = reservation.getDateFrom().until(reservation.getDateTo(), ChronoUnit.DAYS) + 1;
+
         Double exchange = reservation.getDepartmentTake().getCountry().getExchange();
         Double multiplier = exchange * reservation.getDepartmentTake().getMultiplier();
-        double returnPrice = (double) Math.round((cv.getDeptReturnPriceDiff() * multiplier) * 100)/100;
 
-        double rawValue = (double) Math.round((days * reservation.getCarBase().getPriceDay() * multiplier) * 100)/100;
-        double depositValue = (double) Math.round((reservation.getCarBase().getDepositValue() * exchange) * 100)/100;
+        double rawValue = u.roundCurrency(days * reservation.getCarBase().getPriceDay() * multiplier);
+        double depositValue = u.roundCurrency(reservation.getCarBase().getDepositValue() * exchange);
+
         if (!reservation.getDepartmentBack().equals(reservation.getDepartmentTake())) {
+            double returnPrice = u.roundCurrency(cv.getDeptReturnPriceDiff() * multiplier);
             double payment = rawValue + returnPrice;
+
             repository.save(new PaymentDetails(rawValue, returnPrice, depositValue, payment, depositValue, reservation));
         } else {
             repository.save(new PaymentDetails(rawValue, 0.0, depositValue, rawValue, depositValue, reservation));
@@ -62,28 +67,41 @@ public class PaymentDetailsService {
         return repository.findByOperationId(operationId);
     }
 
-    public double calculateChargedDeposit(PaymentDetails paymentDetails) {
-        return paymentDetails.getInitialDeposit() - paymentDetails.getReleasedDeposit() - paymentDetails.getDeposit();
+    public double calculateOvercharge(PaymentDetails paymentDetails) {
+        double payment = paymentDetails.getInitialCarFee() + paymentDetails.getInitialDivergenceFee();
+        return paymentDetails.getSecured() - payment;
     }
 
     @Transactional
-    public void securePayment(PaymentDetails paymentDetails) {
-        paymentDetails.setSecured(paymentDetails.getPayment());
-        paymentDetails.setPayment(0);
-        repository.save(paymentDetails);
+    public void processPayment(PaymentDetails pd) {
+        // Would require method to actually send money back to customer account
+        pd.setSecured(pd.getPayment());
+        pd.setPayment(0);
+
+        double excessDeposit = pd.getDeposit() - pd.getInitialDeposit();
+
+        if (excessDeposit > 0) {
+            pd.setDeposit(pd.getInitialDeposit());
+            pd.setReleasedDeposit(u.roundCurrency(pd.getReleasedDeposit() + excessDeposit));
+        }
+
+        repository.save(pd);
     }
 
     @Transactional
     public void adjustRequiredDeposit(Reservation r, Double depositValue) {
-        Optional<PaymentDetails> pd = repository.findByOperationId(r.getId());
-        if (pd.isEmpty()) return;
-        pd.get().setInitialDeposit(depositValue);
-        repository.save(pd.get());
+        Optional<PaymentDetails> opd = repository.findByOperationId(r.getId());
+        if (opd.isEmpty()) return;
+
+        PaymentDetails pd = opd.get();
+        pd.setInitialDeposit(u.roundCurrency(depositValue));
+        repository.save(pd);
     }
 
     @Transactional
-    public HttpStatus transferDeposit(Long operationId, Double value, boolean isCharge) {
+    public HttpStatus transferDeposit(Long operationId, String deposit, boolean isCharge) {
         try {
+            double value = u.roundCurrency(Double.parseDouble(deposit));
             Optional<PaymentDetails> opd = repository.findByOperationId(operationId);
             if (opd.isEmpty()) throw new ResourceNotFoundException();
 
@@ -91,11 +109,11 @@ public class PaymentDetailsService {
             if (pd.getDeposit() < value || value < 0) throw new IllegalActionException();
 
             if (isCharge) {
-                pd.setDeposit(Math.round((pd.getDeposit() - value) * 100.0) / 100.0);
-                pd.setSecured(Math.round((pd.getSecured() + value) * 100.0) / 100.0);
+                pd.setDeposit(u.roundCurrency(pd.getDeposit() - value));
+                pd.setSecured(u.roundCurrency(pd.getSecured() + value));
             } else {
-                pd.setDeposit(Math.round((pd.getDeposit() - value) * 100.0) / 100.0);
-                pd.setReleasedDeposit(Math.round((pd.getReleasedDeposit() + value) * 100.0) / 100.0);
+                pd.setDeposit(u.roundCurrency(pd.getDeposit() - value));
+                pd.setReleasedDeposit(u.roundCurrency(pd.getReleasedDeposit() + value));
             }
 
             repository.save(pd);
@@ -107,6 +125,9 @@ public class PaymentDetailsService {
         } catch (IllegalActionException err) {
             TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
             return HttpStatus.NOT_ACCEPTABLE;
+        } catch (IllegalArgumentException e) {
+            TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
+            return HttpStatus.BAD_REQUEST;
         } catch (RuntimeException err) {
             TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
             return HttpStatus.INTERNAL_SERVER_ERROR;

--- a/src/main/java/com/sda/carrental/web/mvc/form/property/cars/UpdateCarBasePricesForm.java
+++ b/src/main/java/com/sda/carrental/web/mvc/form/property/cars/UpdateCarBasePricesForm.java
@@ -1,6 +1,7 @@
 package com.sda.carrental.web.mvc.form.property.cars;
 
 import com.sda.carrental.web.mvc.form.common.ConfirmationForm;
+import com.sda.carrental.web.mvc.form.validation.constraint.DoubleValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -13,10 +14,11 @@ import javax.validation.constraints.Positive;
 @RequiredArgsConstructor
 @AllArgsConstructor
 public class UpdateCarBasePricesForm extends ConfirmationForm {
-
     @Positive(message = "Failure: Price value must be positive.")
-    private Double price;
+    @DoubleValue
+    private String price;
 
     @Positive(message = "Failure: Deposit value must be positive.")
-    private Double deposit;
+    @DoubleValue
+    private String deposit;
 }

--- a/src/main/java/com/sda/carrental/web/mvc/form/property/payments/DepositForm.java
+++ b/src/main/java/com/sda/carrental/web/mvc/form/property/payments/DepositForm.java
@@ -1,6 +1,7 @@
 package com.sda.carrental.web.mvc.form.property.payments;
 
 import com.sda.carrental.web.mvc.form.common.ConfirmationForm;
+import com.sda.carrental.web.mvc.form.validation.constraint.DoubleValue;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,7 +12,7 @@ import javax.validation.constraints.*;
 @Setter
 @NoArgsConstructor
 public class DepositForm extends ConfirmationForm {
-    @NotEmpty(message = "Field must contain a value")
-    @Pattern(regexp = "^\\d+,?\\d{0,2}$", message = "Incorrect value format")
+    @NotEmpty(message = "Failure: Field must contain a value.")
+    @DoubleValue
     private String value;
 }

--- a/src/main/java/com/sda/carrental/web/mvc/form/validation/constraint/DoubleValue.java
+++ b/src/main/java/com/sda/carrental/web/mvc/form/validation/constraint/DoubleValue.java
@@ -1,0 +1,21 @@
+package com.sda.carrental.web.mvc.form.validation.constraint;
+
+import com.sda.carrental.web.mvc.form.validation.validator.DoubleValueValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {DoubleValueValidator.class})
+public @interface DoubleValue {
+    String message() default "Failure: Incorrect value format.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/sda/carrental/web/mvc/form/validation/validator/DoubleValueValidator.java
+++ b/src/main/java/com/sda/carrental/web/mvc/form/validation/validator/DoubleValueValidator.java
@@ -1,0 +1,23 @@
+package com.sda.carrental.web.mvc.form.validation.validator;
+
+import com.sda.carrental.web.mvc.form.validation.constraint.DoubleValue;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class DoubleValueValidator implements ConstraintValidator<DoubleValue, String> {
+    @Override
+    public void initialize(DoubleValue constraint) {
+    }
+
+    @Override
+    public boolean isValid(String input, ConstraintValidatorContext cvc) {
+        try {
+            if (input == null) return false;
+            Double.parseDouble(input);
+            return true;
+        } catch (RuntimeException err) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/sda/carrental/web/mvc/management/ArchiveController.java
+++ b/src/main/java/com/sda/carrental/web/mvc/management/ArchiveController.java
@@ -79,7 +79,7 @@ public class ArchiveController {
             map.addAttribute("previousPage", map.getOrDefault("previousPage", "/archive"));
 
             PaymentDetails paymentDetails = paymentDetailsService.getOptionalPaymentDetails(operationId).orElseThrow(ResourceNotFoundException::new);
-            map.addAttribute("charged_deposit", paymentDetailsService.calculateChargedDeposit(paymentDetails));
+            map.addAttribute("charged_deposit", paymentDetailsService.calculateOvercharge(paymentDetails));
 
             map.addAttribute("rent", rent);
             map.addAttribute("isComplete", retrieveOptional.isPresent());

--- a/src/main/java/com/sda/carrental/web/mvc/management/ManageCarBasesController.java
+++ b/src/main/java/com/sda/carrental/web/mvc/management/ManageCarBasesController.java
@@ -83,7 +83,7 @@ public class ManageCarBasesController {
             map.addAttribute("confirmation_form", new ConfirmationForm());
             map.addAttribute("update_image_form", new UpdateCarBaseImageForm());
             map.addAttribute("split_form", map.getOrDefault("split_form", new SplitCarBaseForm()));
-            map.addAttribute("update_price_form", map.getOrDefault("update_price_form", new UpdateCarBasePricesForm(carBase.getPriceDay(), carBase.getDepositValue())));
+            map.addAttribute("update_price_form", map.getOrDefault("update_price_form", new UpdateCarBasePricesForm(carBase.getPriceDay().toString(), carBase.getDepositValue().toString())));
             map.addAttribute("register_form", map.getOrDefault("register_form", new RegisterCarForm(carBase.getId())));
 
             map.addAttribute("result", carBase);

--- a/src/main/java/com/sda/carrental/web/mvc/management/ManageDepositController.java
+++ b/src/main/java/com/sda/carrental/web/mvc/management/ManageDepositController.java
@@ -1,7 +1,6 @@
 package com.sda.carrental.web.mvc.management;
 
 import com.sda.carrental.exceptions.ResourceNotFoundException;
-import com.sda.carrental.global.Utility;
 import com.sda.carrental.model.operational.Retrieve;
 import com.sda.carrental.model.property.Department;
 import com.sda.carrental.model.property.PaymentDetails;
@@ -25,8 +24,6 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/mg-depo")
 public class ManageDepositController {
-
-    private final Utility utility;
     private final RetrieveService retrieveService;
     private final UserService userService;
     private final PaymentDetailsService paymentDetailsService;
@@ -73,7 +70,7 @@ public class ManageDepositController {
             map.addAttribute("retrieve", retrieve);
             map.addAttribute("deadline", retrieveService.replaceDatesWithDeadlines(List.of(retrieve)).get(0).getDateTo());
             map.addAttribute("payment_details", paymentDetails);
-            map.addAttribute("charged_deposit", paymentDetailsService.calculateChargedDeposit(paymentDetails));
+            map.addAttribute("charged_deposit", paymentDetailsService.calculateOvercharge(paymentDetails));
             map.addAttribute("rent_employee", userService.findById(retrieve.getRent().getEmployeeId()));
             map.addAttribute("retrieve_employee", userService.findById(retrieve.getEmployeeId()));
 
@@ -125,8 +122,7 @@ public class ManageDepositController {
             return "redirect:/mg-depo/{retrieve}";
         }
 
-        HttpStatus status = paymentDetailsService.transferDeposit(retrieveId, utility.valueToDouble(form.getValue()), false);
-
+        HttpStatus status = paymentDetailsService.transferDeposit(retrieveId, form.getValue(), false);
         if (status.equals(HttpStatus.OK)) {
             redAtt.addFlashAttribute(MSG_KEY, "Success: Value successfully released from deposit");
         } else if (status.equals(HttpStatus.NOT_ACCEPTABLE)) {
@@ -153,8 +149,7 @@ public class ManageDepositController {
             redAtt.addFlashAttribute(MSG_KEY, err.getAllErrors().get(0).getDefaultMessage());
             return "redirect:/mg-depo/{retrieve}";
         }
-
-        HttpStatus status = paymentDetailsService.transferDeposit(retrieveId, utility.valueToDouble(form.getValue()), true);
+        HttpStatus status = paymentDetailsService.transferDeposit(retrieveId, form.getValue(), true);
 
         if (status.equals(HttpStatus.OK)) {
             redAtt.addFlashAttribute(MSG_KEY, "Success: Value successfully charged from deposit");

--- a/src/main/resources/templates/management/viewCarBase.html
+++ b/src/main/resources/templates/management/viewCarBase.html
@@ -309,14 +309,14 @@
                             <label style="justify-self: start;" for="r_price" class="form-label" th:text="'Price/Day [' + ${placeholder_country.currency} + ']:'"></label>
                             <input id="r_price" class="text-black bg-white modal-input"
                                    th:placeholder="'Provide initial price per day'"
-                                   th:type="number" th:field="*{price}"
+                                   th:type="number" step="0.1" th:field="*{price}"
                                    required/>
                         </div>
                         <div class="modal-row mt-2">
                             <label style="justify-self: start;" for="r_deposit" class="form-label" th:text="'Deposit [' + ${placeholder_country.currency} + ']:'"></label>
                             <input id="r_deposit" class="text-black bg-white modal-input"
                                    th:placeholder="'Provide initial deposit value'"
-                                   th:type="number" th:field="*{deposit}"
+                                   th:type="number" step="0.1" th:field="*{deposit}"
                                    required/>
                         </div>
                         <div class="modal-row mt-2">

--- a/src/main/resources/templates/management/viewDeposit.html
+++ b/src/main/resources/templates/management/viewDeposit.html
@@ -117,14 +117,14 @@
                     </div>
 
                     <div style="margin-top: 20%;"
-                         th:utext="'<strong>Deposit:</strong>'">
+                         th:utext="'<strong>Reservation<br>deposit:</strong>'">
                     </div>
                     <div style="margin-top: 2%;"
                          th:text="${payment_details.initialDeposit}">
                     </div>
 
                     <div th:if="${payment_details.deposit > 0}" style="margin-top: 20%;"
-                         th:utext="'<strong>Balance:</strong>'">
+                         th:utext="'<strong>Remaining<br>balance:</strong>'">
                     </div>
                     <div th:if="${payment_details.deposit > 0}" style="margin-top: 2%;"
                          th:text="${payment_details.deposit}">
@@ -193,8 +193,8 @@
                                             <div class="form-group">
                                                 <label for="r_value"
                                                        class="col-form-label">Release value:</label>
-                                                <input id="r_value" class="text-black bg-white" name="r_value"
-                                                       placeholder="0000,00" th:field="*{value}" required/>
+                                                <input id="r_value" class="text-black bg-white" name="r_value" type="number" step="0.1"
+                                                       placeholder="000.00" th:field="*{value}" required/>
                                             </div>
                                             <div class="form-group">
                                                 <label for="r_password" class="col-form-label">Confirm action with a
@@ -248,7 +248,7 @@
                                             <div class="form-group">
                                                 <label for="c_value"
                                                        class="col-form-label">Charge value:</label>
-                                                <input id="c_value" class="text-black bg-white" placeholder="0000,00"
+                                                <input id="c_value" class="text-black bg-white" placeholder="000.00" type="number" step="0.1"
                                                        name="c_value" th:field="*{value}" required/>
                                             </div>
                                             <div class="form-group">

--- a/src/main/resources/templates/management/viewOperation.html
+++ b/src/main/resources/templates/management/viewOperation.html
@@ -127,14 +127,14 @@
                     </div>
 
                     <div style="margin-top: 20%;"
-                         th:utext="'<strong>Deposit:</strong>'">
+                         th:utext="'<strong>Reservation<br>deposit:</strong>'">
                     </div>
                     <div style="margin-top: 2%;"
                          th:text="${payment_details.initialDeposit}">
                     </div>
 
                     <div th:if="${payment_details.deposit > 0}" style="margin-top: 20%;"
-                         th:utext="'<strong>Balance:</strong>'">
+                         th:utext="'<strong>Remaining<br>balance:</strong>'">
                     </div>
                     <div th:if="${payment_details.deposit > 0}" style="margin-top: 2%;"
                          th:text="${payment_details.deposit}">


### PR DESCRIPTION
fix/incorrect calculation of charged value in mg-depo and archive 
update/added validator meant for double values
update/added Utility method that rounds value to 2 decimal places 
update/renting now automatically returns deposit value that is over required value 
update/added steps to viewDeposit and viewCarBase double inputs 
rename/calculatedCharge method name to be more precise calculatedOvercharge 
rename/securePayment method name to processPayment due to addition of overcharge return 
rename/constructor initial deposit param to more concise required deposit 
removed/Utility method that parsed String from german decimal type input